### PR TITLE
JSON PHP extension is required in WP 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
   },
   "require": {
     "php": ">=5.6.20",
+    "ext-json": "*",
     "johnpbloch/wordpress-core-installer": "^1.0",
     "johnpbloch/wordpress-core": "dev-master"
   }


### PR DESCRIPTION
@johnpbloch See https://make.wordpress.org/core/2019/10/15/php-native-json-extension-now-required/