### PR TITLE
Change domain protocols to `https` in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,20 +7,20 @@
     "cms"
   ],
   "type": "package",
-  "homepage": "http://wordpress.org/",
+  "homepage": "https://wordpress.org/",
   "license": "GPL-2.0+",
   "authors": [
     {
       "name": "WordPress Community",
-      "homepage": "http://wordpress.org/about/"
+      "homepage": "https://wordpress.org/about/"
     }
   ],
   "support": {
-    "issues": "http://core.trac.wordpress.org/",
-    "forum": "http://wordpress.org/support/",
-    "wiki": "http://codex.wordpress.org/",
+    "issues": "https://core.trac.wordpress.org/",
+    "forum": "https://wordpress.org/support/",
+    "docs": "https://developer.wordpress.org/",
     "irc": "irc://irc.freenode.net/wordpress",
-    "source": "http://core.trac.wordpress.org/browser"
+    "source": "https://core.trac.wordpress.org/browser"
   },
   "require": {
     "php": ">=5.6.20",


### PR DESCRIPTION
Also, change `wiki` item (which links to outdated WordPress Codex) to `docs` and link to https://developer.wordpress.org/.